### PR TITLE
Dictionaries can now use enums as keys

### DIFF
--- a/TinyJSON/JSON.cs
+++ b/TinyJSON/JSON.cs
@@ -360,10 +360,20 @@ namespace TinyJSON
 		private static Dictionary<K,V> DecodeDictionary<K,V>( Variant data )
 		{
 			var dict = new Dictionary<K,V>();
+			var keyType = typeof(K);
 
 			foreach (var pair in data as ProxyObject)
 			{
-				var k = (K) Convert.ChangeType( pair.Key, typeof(K) );
+				K k;
+
+				if (keyType.IsEnum) 
+				{
+					k = (K)Enum.Parse(keyType, pair.Key);
+				} 
+				else 
+				{
+					k = (K)Convert.ChangeType(pair.Key, keyType);
+				}
 				var v = DecodeType<V>( pair.Value );
 				dict.Add( k, v );
 			}


### PR DESCRIPTION
I've gone ahead and fixed Issue #5. 

Just a note for any other potential contributor: this project is indented using tabs while Visual Studio's default behaviour (for me at least) is to use spaces. It took enough time just to figure it out, let alone fix it.

In response to your concern:
> We would also need to ensure the enum is being encoded as its full qualified name and not a number string.

For me the key is being encoded with the correct enum type so it should be fine. 

My data is finally serializing and de-serializing successfully after days of wrangling with the DataContractSerializer class. 