### PR TITLE
Feature to Dump directly into a File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ NUnit/
 packages
 /.idea
 /TinyJSON.cs
+.vs

--- a/TinyJSON.sln
+++ b/TinyJSON.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TinyJSON", "TinyJSON\TinyJSON.csproj", "{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example", "Example\Example.csproj", "{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}"
@@ -9,52 +11,32 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\Unit
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-		Debug|iPhoneSimulator = Debug|iPhoneSimulator
-		Release|iPhoneSimulator = Release|iPhoneSimulator
-		Debug|iPhone = Debug|iPhone
-		Release|iPhone = Release|iPhone
+		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU
 		Ad-Hoc|iPhone = Ad-Hoc|iPhone
+		Ad-Hoc|iPhoneSimulator = Ad-Hoc|iPhoneSimulator
+		AppStore|Any CPU = AppStore|Any CPU
 		AppStore|iPhone = AppStore|iPhone
+		AppStore|iPhoneSimulator = AppStore|iPhoneSimulator
+		Debug|Any CPU = Debug|Any CPU
+		Debug|iPhone = Debug|iPhone
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|Any CPU = Release|Any CPU
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|iPhone.Build.0 = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhone.Build.0 = Release|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|iPhone.Build.0 = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhone.Build.0 = Release|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Ad-Hoc|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.AppStore|Any CPU.Build.0 = Release|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.AppStore|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.AppStore|iPhoneSimulator.Build.0 = Release|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -67,6 +49,60 @@ Global
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Release|iPhone.Build.0 = Release|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{B7E22DAC-A8C9-4E8B-A7F7-F8336836CAFD}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Ad-Hoc|iPhoneSimulator.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|Any CPU.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.AppStore|iPhoneSimulator.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhone.Build.0 = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{8BBC60F1-CEB1-40FC-904C-B681495ADAB6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Ad-Hoc|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|Any CPU.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.AppStore|iPhoneSimulator.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhone.Build.0 = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{2CA10905-12EB-4550-9FCF-AEA9572E3B88}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30F83547-4769-41B2-AE26-4DE463570F78}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/TinyJSON/JSON.cs
+++ b/TinyJSON/JSON.cs
@@ -124,25 +124,45 @@ namespace TinyJSON
 		public static string Dump( object data, EncodeOptions options )
 		{
 			// Invoke methods tagged with [BeforeEncode] attribute.
+			InvokeBeforeEncode( data );
+			return Encoder.Encode( data, options );
+		}
+
+
+		public static void DumpToFile( object data, string filePath )
+		{
+			DumpToFile( data, filePath, EncodeOptions.None );
+		}
+
+
+		public static void DumpToFile( object data, string filePath, EncodeOptions options )
+		{
+			if (string.IsNullOrEmpty(filePath)) throw new ArgumentException("filePath is null or empty");
+			// Invoke methods tagged with [BeforeEncode] attribute.
+			InvokeBeforeEncode( data );
+			Encoder.EncodeToFile( data, filePath, options );
+		}
+
+
+		private static void InvokeBeforeEncode( object data )
+		{
 			if (data != null)
 			{
 				var type = data.GetType();
 				if (!(type.IsEnum || type.IsPrimitive || type.IsArray))
 				{
-					foreach (var method in type.GetMethods( instanceBindingFlags ))
+					foreach (var method in type.GetMethods(instanceBindingFlags))
 					{
-						if (method.GetCustomAttributes( false ).AnyOfType( typeof(BeforeEncode) ))
+						if (method.GetCustomAttributes(false).AnyOfType(typeof(BeforeEncode)))
 						{
 							if (method.GetParameters().Length == 0)
 							{
-								method.Invoke( data, null );
+								method.Invoke(data, null);
 							}
 						}
 					}
 				}
 			}
-
-			return Encoder.Encode( data, options );
 		}
 
 


### PR DESCRIPTION
The Dump method in TinyJSON works reasonably well for smaller data objects, but dumping a large object can be RAM intensive. This circumvents that issue in the scenario where the user wants to save the object directly to a file. The new DumpToFile method is very RAM efficient at the expense of being more restrictive in scope and having a slightly longer processing time.